### PR TITLE
Migrate to a plugin based api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build status](https://badge.buildkite.com/2ac76cfb209dae257969b7464a2c90834ed82705cfd5bfcc52.svg?branch=master)](https://buildkite.com/uberopensource/fusion-apollo)
 
-Fusion.js entry point for React universal rendering with Apollo
+Fusion.js plugin for universal rendering with React and Apollo
 
-Provides a Fusion.js application class that is pre-configured with React and Apollo universal rendering for applications leveraging GraphQL.
+This package provides universal rendering for Fusion.js applications leveraging GraphQL. 
 
-The App class from this package should be used when you want to perform both server and client rendering with GraphQL querying. This package will also provide initial state hydration on the client.
+The plugin will perform graphql queries on the server, thereby rendering your applications initial HTML view on the server before sending it to the client. Additionally this plugin will also provide initial state hydration on the client side.
 
 ---
 
@@ -19,7 +19,7 @@ The App class from this package should be used when you want to perform both ser
     - [`ApolloClientToken`](#apolloclienttoken)
     - [`ApolloContextToken`](#apollocontexttoken)
     - [`GraphQLSchemaToken`](#graphqlschematoken)
-  - [App](#app)
+  - [Plugin](#plugin)
   - [Provider](#providers)
 
 ---
@@ -37,11 +37,17 @@ yarn add fusion-apollo
 ```js
 // ./src/main.js
 import React from 'react';
-import App, {ApolloClientToken} from 'fusion-apollo';
+import App from 'fusion-react';
+import {RenderToken} from 'fusion-core';
+
+// New import provided by this plugin
+import ApolloPlugin, {ApolloClientToken} from 'fusion-apollo';
+// A barebones Apollo Client
 import ApolloClient from 'fusion-apollo-universal-client';
 
 export default function() {
   const app = new App(<Hello />);
+  app.register(RenderToken, ApolloPlugin)
   app.register(ApolloClientToken, ApolloClient);
   return app;
 }
@@ -63,8 +69,6 @@ const schema = gql('./some-schema.graphql');
 ---
 
 ### API
-
-#### Registration API
 
 ##### ApolloClientToken
 
@@ -108,29 +112,14 @@ Define the `GraphQLSchemaToken` when using a locally hosted GraphQL endpoint fro
 type GraphQLSchema = string;
 ```
 
-#### App
+#### Plugin
 
 ```js
-import App from 'fusion-apollo';
+import ApolloPlugin from 'fusion-apollo';
 ```
 
-A class that represents an application. An application is responsible for rendering (both virtual DOM and server-side rendering). The functionality of an application is extended via [plugins](https://github.com/fusionjs/fusion-core#plugin).
+A plugin which is responsible for rendering (both virtual DOM and server-side rendering).
 
-**Constructor**
-
-```js
-const app: App = new App(
-  (el: ReactElement),
-  (render: ?(el: ReactElement) => string)
-);
-```
-
-- `el: ReactElement` - a template root. In a React application, this would be a React element created via `React.createElement` or a JSX expression.
-- `render: ?(el:ReactElement) => string` - Optional. Defines how rendering should occur. 
-
-**app.(register|middleware|enhance|cleanup)**
-
-See the [fusion-core app methods](https://github.com/fusionjs/fusion-core#app) for further information on provided methods. Fusion-apollo does not add additional app methods besides the inherited fusion-core methods.
 
 #### gql
 
@@ -149,11 +138,3 @@ type gql = (path: string): string
 - `path: string` - Relative path to the graphql schema/query file. NOTE: This must be a string literal, dynamic paths are not supported.
 
 ---
-
-#### Providers
-
-As a convenience, fusion-apollo re-exports providers from fusion-react. You can find additional information on those as follows:
-
-- [Provider](https://github.com/fusionjs/fusion-react/blob/master/README.md#provider)
-- [ProviderPlugin](https://github.com/fusionjs/fusion-react/blob/master/README.md#providerplugin)
-- [ProvidedHOC](https://github.com/fusionjs/fusion-react/blob/master/README.md#providedhoc)

--- a/package.json
+++ b/package.json
@@ -21,11 +21,9 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
-  "dependencies": {
-    "fusion-react": "1.3.7"
-  },
   "peerDependencies": {
     "fusion-core": "^1.10.3",
+    "fusion-react": "^2.0.0",
     "fusion-tokens": "^1.1.1",
     "react": "16.x",
     "react-apollo": "^2.0.4",
@@ -47,7 +45,8 @@
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.92.0",
-    "fusion-core": "^1.10.0",
+    "fusion-core": "^1.10.1",
+    "fusion-react": "^2.0.0",
     "fusion-test-utils": "^1.3.0",
     "fusion-tokens": "^1.1.1",
     "graphql": "^14.1.1",

--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -1,40 +1,19 @@
 // @flow
 
 import test from 'tape-cup';
-import React from 'react';
-import App, {
+import plugin, {
   ApolloClientToken,
   ApolloContextToken,
   GraphQLSchemaToken,
   gql,
 } from '../index.js';
-import {getSimulator} from 'fusion-test-utils';
 
 test('fusion-tokens exports', t => {
   t.ok(ApolloClientToken, 'exports ApolloClientToken');
   t.ok(ApolloContextToken, 'exports ApolloContextToken');
   t.ok(GraphQLSchemaToken, 'exports GraphQLSchemaToken');
-  t.ok(App, 'exports App');
+  t.ok(plugin, 'exports plugin');
   t.equal(typeof gql, 'function', 'exports a gql function');
   t.throws(gql, 'gql function throws an error if executed directly');
-  t.end();
-});
-
-test('App with custom render function', async t => {
-  const app = new App(<div>Hello world</div>, el => {
-    t.ok(el);
-    return 'rendered';
-  });
-  app.register(ApolloClientToken, () => {
-    // $FlowFixMe
-    return {
-      cache: {
-        extract: () => {},
-      },
-    };
-  });
-  const simulator = getSimulator(app);
-  const ctx = await simulator.render('/');
-  t.equal(ctx.rendered, 'rendered', 'custom render function called');
   t.end();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -9,20 +9,11 @@
 /* eslint-env browser */
 import React from 'react';
 
-import CoreApp, {createPlugin, createToken, html, unescape} from 'fusion-core';
+import {createPlugin, createToken, html, unescape} from 'fusion-core';
 import type {ApolloClient} from 'apollo-client';
 
 import {ApolloProvider} from 'react-apollo';
 
-import {
-  ProviderPlugin,
-  ProvidedHOC,
-  Provider,
-  prepare,
-  middleware,
-} from 'fusion-react';
-
-import type {Element} from 'react';
 import type {Context, Token} from 'fusion-core';
 
 import serverRender from './server';
@@ -52,70 +43,55 @@ export const ApolloCacheContext = React.createContext<
   $PropertyType<InitApolloClientType<mixed>, 'cache'>
 >();
 
-export default class App extends CoreApp {
-  constructor(root: Element<*>, render: ?(Element<*>, ctx: Context) => any) {
-    const renderer = createPlugin({
-      deps: {
-        getApolloClient: ApolloClientToken,
-        logger: LoggerToken.optional,
-      },
-      provides({logger}) {
-        return (el, ctx) => {
-          return prepare(el).then(() => {
-            return render
-              ? render(el, ctx)
-              : __NODE__
-              ? serverRender(el, logger)
-              : clientRender(el);
-          });
-        };
-      },
-      middleware({getApolloClient}) {
-        // This is required to set apollo client/root on context before creating the client.
-        return (ctx, next) => {
-          if (!ctx.element) {
-            return next();
-          }
+export default createPlugin({
+  deps: {
+    getApolloClient: ApolloClientToken,
+    logger: LoggerToken.optional,
+  },
+  provides({logger}) {
+    return (el, ctx) => {
+      return __NODE__ ? serverRender(el, logger) : clientRender(el);
+    };
+  },
 
-          // Deserialize initial state for the browser
-          let initialState = null;
-          if (__BROWSER__) {
-            const apolloState = document.getElementById('__APOLLO_STATE__');
-            if (apolloState) {
-              initialState = JSON.parse(unescape(apolloState.textContent));
-            }
-          }
+  middleware({getApolloClient}) {
+    // This is required to set apollo client/root on context before creating the client.
+    return (ctx, next) => {
+      if (!ctx.element) {
+        return next();
+      }
 
-          // Create the client and apollo provider
-          const client = getApolloClient(ctx, initialState);
-          ctx.element = (
-            <ApolloCacheContext.Provider value={client.cache}>
-              <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
-            </ApolloCacheContext.Provider>
-          );
+      // Deserialize initial state for the browser
+      let initialState = null;
+      if (__BROWSER__) {
+        const apolloState = document.getElementById('__APOLLO_STATE__');
+        if (apolloState) {
+          initialState = JSON.parse(unescape(apolloState.textContent));
+        }
+      }
 
-          if (__NODE__) {
-            return middleware(ctx, next).then(() => {
-              const initialState = client.cache && client.cache.extract();
-              const serialized = JSON.stringify(initialState);
-              const script = html`
-                <script type="application/json" id="__APOLLO_STATE__">
-                  ${serialized}
-                </script>
-              `;
-              ctx.template.body.push(script);
-            });
-          } else {
-            return middleware(ctx, next);
-          }
-        };
-      },
-    });
-    super(root, renderer);
-  }
-}
+      // Create the client and apollo provider
+      const client = getApolloClient(ctx, initialState);
+      ctx.element = (
+        <ApolloCacheContext.Provider value={client.cache}>
+          <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
+        </ApolloCacheContext.Provider>
+      );
 
-export {ProviderPlugin, ProvidedHOC, Provider};
+      if (__NODE__) {
+        const initialState = client.cache && client.cache.extract();
+        const serialized = JSON.stringify(initialState);
+        const script = html`
+          <script type="application/json" id="__APOLLO_STATE__">
+            ${serialized}
+          </script>
+        `;
+        ctx.template.body.push(script);
+      }
+      return next();
+    };
+  },
+});
 
 export function gql(path: string): string {
   throw new Error('fusion-apollo/gql should be replaced at build time');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,10 +2626,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-fusion-core@^1.10.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.10.1.tgz#99a0f2a3dcb1554db87a2b102b7fc031a7b9960d"
-  integrity sha512-XtJc5speIp0Yl0fwx3ri6TRgxQ+G9tW4l5ikMxScQ76yw5MSaXPl8vZwOcUwLjggWcs4oaeIFoV4idkvsQZukw==
+fusion-core@^1.10.1:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.10.4.tgz#4e0f4e54d4b9992e1a8a31f3dcf2f5e2c8cde8d0"
+  integrity sha512-KAbIXOKLSwek8lKjnx6ChaFE9JgMvhazMh/tmWlDYPtebu3s/JL++I7qZ8chJ8BcO7IhdhjueRZ0IM/2oqFDGA==
   dependencies:
     koa "^2.6.2"
     koa-compose "^4.1.0"
@@ -2638,13 +2638,12 @@ fusion-core@^1.10.0:
     ua-parser-js "^0.7.19"
     uuid "^3.3.2"
 
-fusion-react@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.3.7.tgz#7ece897feff9ef67c33f13f376929fd5a1e471f6"
-  integrity sha512-Zs60GxwkjEkDb2jqcdxnWmGDxUDtD8VJmT6ipnr66oXQHSDl3iMtUDQIXFFg9mZG6jeRFF+BAK1Bhf3SMKt2PQ==
+fusion-react@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-2.0.0.tgz#74c0a9787c6b1db03af2195cb45a8ec27fbc1191"
+  integrity sha512-eN2miThQCo7iGYvjaJtRv7qZBwSX9rUje1RNIp/NvVYHuBPvdfg3DmXlg8OWBx5y4tMFMOOu2DepcyUlrgVSbg==
   dependencies:
     prop-types "^15.6.2"
-    react-is "^16.7.0"
 
 fusion-test-utils@^1.3.0:
   version "1.3.1"
@@ -4645,7 +4644,7 @@ react-dom@^16.6.3:
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
-react-is@^16.3.2, react-is@^16.7.0:
+react-is@^16.3.2:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==


### PR DESCRIPTION
Changes:
* Fixes #141
* Removes the custom App and instead leverages the fusion-react base
class along with a render token provided plugin.
* Updates and includes the latest fusion-react as a peer dependency.

This has major breaking changes from the existing api, but in the long
run will be a net positive in how it:

* Leverages the code, bug fixes, etc. on the main fusion-react plugin.
* Removes the duplication of exports from the aforementioned plugin.