### PR TITLE
Release v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-apollo",
   "description": "FusionJS entry point for React universal rendering /w Apollo",
-  "version": "1.6.1-0",
+  "version": "1.6.1",
   "license": "MIT",
   "repository": "fusionjs/fusion-apollo",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Return DocumentNode when calling `gql` ([#147](https://github.com/fusionjs/fusion-plugin-apollo/pull/147))