### PR TITLE
Add support for graphql middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The plugin will perform graphql queries on the server, thereby rendering your ap
     - [`ApolloClientToken`](#apolloclienttoken)
     - [`GraphQLSchemaToken`](#graphqlschematoken)
     - [`GraphQLEndpointToken`](#graphqlendpointtoken)
+    - [`GraphQLMiddlewareToken`](#graphqlmiddlewaretoken)
   - [Plugin](#plugin)
   - [Provider](#providers)
 
@@ -74,6 +75,30 @@ const query = gql('./some-query.graphql');
 const schema = gql('./some-schema.graphql');
 ```
 
+### Middleware
+
+`fusion-plugin-apollo` ships with graphql middleware support using the [`graphql-middleware`](https://github.com/prisma/graphql-middleware/) package. This can be useful for incorporating logging, tracing, and metrics into your graphql server.
+
+```js
+import {GraphQLMiddlewareToken} from 'fusion-plugin-apollo';
+
+const logInput = async (resolve, root, args, context, info) => {
+  console.log(`1. logInput: ${JSON.stringify(args)}`)
+  const result = await resolve(root, args, context, info)
+  console.log(`5. logInput`)
+  return result
+}
+
+const logResult = async (resolve, root, args, context, info) => {
+  console.log(`2. logResult`)
+  const result = await resolve(root, args, context, info)
+  console.log(`4. logResult: ${JSON.stringify(result)}`)
+  return result
+}
+
+app.register(GraphQLMiddlewareToken, [logInput, logResult]);
+```
+
 ---
 
 ### API
@@ -122,6 +147,31 @@ Optional - the endpoint for serving the graphql API. Defaults to `'/graphql'`.
 
 ```js
 type GraphQLEndpoint = string;
+```
+
+##### GraphQLMiddlewareToken
+
+```js
+import {GraphQLMiddlewareToken} from 'fusion-plugin-apollo';
+```
+
+Optional - an array of graphql middleware compatible with the [`graphql-middleware`](https://github.com/prisma/graphql-middleware/) package.
+
+```js
+type GraphQLMiddleware = (
+  resolve: ResolveFn,
+  root: any,
+  args: any,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<any>;
+
+type ResolveFn = (
+  root: any,
+  args: any,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<any>;
 ```
 
 #### Plugin

--- a/package.json
+++ b/package.json
@@ -21,13 +21,16 @@
     "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
-  "peerDependencies": {
-    "fusion-core": "^1.10.4",
-    "fusion-react": "^2.0.0",
-    "fusion-tokens": "^1.1.1",
-    "react": "16.x",
-    "react-apollo": "^2.0.4",
-    "react-dom": "16.x"
+  "dependencies": {
+    "apollo-cache-inmemory": "^1.3.12",
+    "apollo-client": "^2.4.7",
+    "apollo-link": "^1.2.9",
+    "apollo-link-http": "^1.5.12",
+    "apollo-link-schema": "^1.1.4",
+    "apollo-server-koa": "^2.4.8",
+    "graphql-middleware": "^3.0.2",
+    "graphql-tools": "^4.0.3",
+    "koa-compose": "^4.1.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
@@ -49,7 +52,6 @@
     "get-port": "^4.2.0",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.0",
-    "graphql-tools": "^4.0.3",
     "node-fetch": "^2.3.0",
     "prettier": "^1.15.2",
     "react": "^16.6.3",
@@ -58,6 +60,14 @@
     "redux": "^4.0.1",
     "tape-cup": "^4.7.1",
     "unitest": "^2.1.1"
+  },
+  "peerDependencies": {
+    "fusion-core": "^1.10.4",
+    "fusion-react": "^2.0.0",
+    "fusion-tokens": "^1.1.1",
+    "react": "16.x",
+    "react-apollo": "^2.0.4",
+    "react-dom": "16.x"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -70,14 +80,5 @@
   },
   "engines": {
     "node": ">= 8.9.0"
-  },
-  "dependencies": {
-    "apollo-cache-inmemory": "^1.3.12",
-    "apollo-client": "^2.4.7",
-    "apollo-link": "^1.2.9",
-    "apollo-link-http": "^1.5.12",
-    "apollo-link-schema": "^1.1.4",
-    "apollo-server-koa": "^2.4.8",
-    "koa-compose": "^4.1.0"
   }
 }

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -12,7 +12,11 @@ import test from 'tape-cup';
 import {getSimulator} from 'fusion-test-utils';
 import React from 'react';
 import render from '../server';
-import plugin, {GraphQLSchemaToken, ApolloClientToken} from '../index';
+import plugin, {
+  GraphQLSchemaToken,
+  ApolloClientToken,
+  GraphQLMiddlewareToken,
+} from '../index';
 import gql from 'graphql-tag';
 import {makeExecutableSchema} from 'graphql-tools';
 import {Query} from 'react-apollo';
@@ -152,5 +156,55 @@ test('SSR with <Query> and errors', async t => {
   const ctx = await simulator.render('/');
   t.equal(ctx.rendered.includes('test'), false, 'does not fetch data');
   t.equal(ctx.rendered.includes('Loading'), true, 'Renders the loading');
+  t.end();
+});
+
+test('GraphQL Middleware', async t => {
+  const query = gql`
+    query Test {
+      test
+    }
+  `;
+  const el = (
+    <div>
+      <Query query={query}>
+        {result => {
+          if (result.loading) {
+            return <div>Loading...</div>;
+          } else if (result.data) {
+            return <div>{result.data.test}</div>;
+          } else {
+            return <div>Failure</div>;
+          }
+        }}
+      </Query>
+    </div>
+  );
+  const typeDefs = gql`
+    type Query {
+      test: String
+    }
+  `;
+  const resolvers = {
+    Query: {
+      test(parent, args, ctx) {
+        t.equal(ctx.path, '/', 'context defaults correctly');
+        return 'test';
+      },
+    },
+  };
+  const app = testApp(el, {typeDefs, resolvers});
+  const middleware = async (resolve, root, args, context, info) => {
+    t.ok(context, 'passes context');
+    t.ok(info, 'passes graphql info');
+    const result = await resolve(root, args, context, info);
+    t.equal(result, 'test');
+    return 'something';
+  };
+  app.register(GraphQLMiddlewareToken, [middleware]);
+  const simulator = getSimulator(app);
+  const ctx = await simulator.render('/');
+  t.equal(ctx.rendered.includes('something'), true, 'renders correctly');
+  t.equal(ctx.rendered.includes('Loading'), false, 'does not render loading');
   t.end();
 });

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import {createToken, type Context, type Token} from 'fusion-core';
 import type {ApolloClient} from 'apollo-client';
+import type {GraphQLResolveInfo} from 'graphql';
 
 export type InitApolloClientType<TInitialState> = (
   ctx: Context,
@@ -34,3 +35,20 @@ export const GraphQLEndpointToken: Token<string> = createToken(
 export const ApolloClientToken: Token<
   InitApolloClientType<mixed>
 > = createToken('ApolloClientToken');
+
+type ResolveFn = (
+  root: any,
+  args: any,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<any>;
+type MiddlewareType = (
+  resolve: ResolveFn,
+  root: any,
+  args: any,
+  context: Context,
+  info: GraphQLResolveInfo
+) => Promise<any>;
+export const GraphQLMiddlewareToken: Token<MiddlewareType[]> = createToken(
+  'GraphQLMiddlewareToken'
+);

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -42,13 +42,13 @@ type ResolveFn = (
   context: Context,
   info: GraphQLResolveInfo
 ) => Promise<any>;
-type MiddlewareType = (
+export type GraphQLMiddlewareType = (
   resolve: ResolveFn,
   root: any,
   args: any,
   context: Context,
   info: GraphQLResolveInfo
 ) => Promise<any>;
-export const GraphQLMiddlewareToken: Token<MiddlewareType[]> = createToken(
-  'GraphQLMiddlewareToken'
-);
+export const GraphQLMiddlewareToken: Token<
+  GraphQLMiddlewareType[]
+> = createToken('GraphQLMiddlewareToken');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3112,6 +3112,13 @@ graphql-extensions@0.5.7:
   dependencies:
     "@apollographql/apollo-tools" "^0.3.3"
 
+graphql-middleware@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-3.0.2.tgz#c8cdb67615eec02aec237b455e679f5fc973ddc4"
+  integrity sha512-sRqu1sF+77z42z1OVM1QDHKQWnWY5K3nAgqWiZwx3U4tqNZprrDuXxSChPMliV343IrVkpYdejUYq9w24Ot3FA==
+  dependencies:
+    graphql-tools "^4.0.4"
+
 graphql-subscriptions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz#475267694b3bd465af6477dbab4263a3f62702b8"
@@ -3124,7 +3131,7 @@ graphql-tag@^2.10.0, graphql-tag@^2.9.2:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql-tools@^4.0.0, graphql-tools@^4.0.3:
+graphql-tools@^4.0.0, graphql-tools@^4.0.3, graphql-tools@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
   integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==


### PR DESCRIPTION
This adds support for graphql middleware via the [`graphql-middleware`](https://github.com/prisma/graphql-middleware/)
package. This can be useful for adding logging, tracing, or metrics to your graphql server.