### PR TITLE
Simplify usage of schema token

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ type ApolloContext<T> = (ctx: Context => T) | T;
 import {GraphQLSchemaToken} from 'fusion-plugin-apollo';
 ```
 
-Your graphql schema is registered on the `GraphQLSchemaToken` token. This can be an Object of `{typeDefs, resolvers}` or the result from `makeExecutableSchema` or `makeRemoteExecutableSchema` from the `graphql-tools` library.
+Your graphql schema is registered on the `GraphQLSchemaToken` token. This is the result of `makeExecutableSchema` or `makeRemoteExecutableSchema` from the `graphql-tools` library.
 
 ##### GraphQLEndpointToken
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "apollo-link-schema": "^1.1.4",
     "apollo-server-koa": "^2.4.8",
     "graphql-middleware": "^3.0.2",
-    "graphql-tools": "^4.0.3",
+    "graphql-tools": "^4.0.4",
     "koa-compose": "^4.1.0"
   },
   "devDependencies": {

--- a/src/__tests__/integration.node.js
+++ b/src/__tests__/integration.node.js
@@ -17,12 +17,13 @@ import {HttpLink} from 'apollo-link-http';
 import getPort from 'get-port';
 import http from 'http';
 import fetch from 'node-fetch';
+import {makeExecutableSchema} from 'graphql-tools';
 
 async function testApp(el, {typeDefs, resolvers}) {
   const port = await getPort();
   const endpoint = `http://localhost:${port}/graphql`;
   const app = new App(el);
-  const schema = {typeDefs, resolvers};
+  const schema = makeExecutableSchema({typeDefs, resolvers});
   const client = new ApolloClient({
     ssrMode: true,
     cache: new InMemoryCache().restore({}),

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,7 +22,6 @@ import {LoggerToken} from 'fusion-tokens';
 import {ApolloServer} from 'apollo-server-koa';
 import compose from 'koa-compose';
 import {applyMiddleware} from 'graphql-middleware';
-import {makeExecutableSchema} from 'graphql-tools';
 
 import {
   ApolloContextToken,
@@ -114,9 +113,6 @@ export default createPlugin<DepsType, ProvidesType>({
       return next();
     };
     if (__NODE__) {
-      if (schema.typeDefs && schema.resolvers) {
-        schema = makeExecutableSchema(schema);
-      }
       if (middleware) {
         schema = applyMiddleware(schema, ...middleware);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3131,7 +3131,7 @@ graphql-tag@^2.10.0, graphql-tag@^2.9.2:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql-tools@^4.0.0, graphql-tools@^4.0.3, graphql-tools@^4.0.4:
+graphql-tools@^4.0.0, graphql-tools@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
   integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==


### PR DESCRIPTION
This simplifies the usage of the SchemaToken to enforce always passing an executable schema, rather
than the option of passing an Object with {typeDefs, resolvers} keys. The main reasoning is there 
should be consistency so that many plugins can depend on the token without needing to update the 
schema.