### PR TITLE
Merge logic from fusion-apollo-universal-client, export multiple plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ The plugin will perform graphql queries on the server, thereby rendering your ap
     - [`ApolloClientToken`](#apolloclienttoken)
     - [`GraphQLSchemaToken`](#graphqlschematoken)
     - [`GraphQLEndpointToken`](#graphqlendpointtoken)
-  - [Plugin](#plugin)
-  - [Provider](#providers)
+    - [`GetApolloClientCacheToken`](#GetApolloClientCacheToken)
+    - [`ApolloClientCredentialsToken`](#apolloclientcredentialstoken)
+    - [`GetApolloClientLinksToken`](#getapolloclientlinkstoken)
+    - [`ApolloClientResolversToken`](#apolloclientresolverstoken)
+  = [GQL Macro]($gql)
 
 ---
 
@@ -41,19 +44,17 @@ import React from 'react';
 import App from 'fusion-react';
 import {RenderToken} from 'fusion-core';
 
-// New import provided by this plugin
-import ApolloPlugin, {
+import {
+  ApolloRenderEnhancer,
+  ApolloClientPlugin,
+  ApolloClientToken,
   GraphQLSchemaToken, 
-  ApolloClientToken
 } from 'fusion-plugin-apollo';
-
-// Plugin which provides an apollo client pre-configured for universal rendering
-import ApolloUniversalClient from 'fusion-apollo-universal-client';
 
 export default function() {
   const app = new App(<Hello />);
-  app.register(RenderToken, ApolloPlugin);
-  app.register(ApolloClientToken, ApolloUniversalClient);
+  app.enhance(RenderToken, ApolloRenderEnhancer);
+  app.register(ApolloClientToken, ApolloClientPlugin);
   if (__NODE__) {
     app.register(GraphQLSchemaToken, YourGraphQLSchema);
   }
@@ -71,20 +72,18 @@ import React from 'react';
 import App from 'fusion-react';
 import {RenderToken} from 'fusion-core';
 
-// New import provided by this plugin
-import ApolloPlugin, {
-  GraphQLEndpointToken,
-  ApolloClientToken
+import {
+  ApolloRenderEnhancer,
+  ApolloClientPlugin,
+  ApolloClientToken,
+  GraphQLSchemaToken, 
 } from 'fusion-plugin-apollo';
-
-// Plugin which provides an apollo client pre-configured for universal rendering
-import ApolloUniversalClient from 'fusion-apollo-universal-client';
 
 export default function() {
   const app = new App(<Hello />);
-  app.register(RenderToken, ApolloPlugin);
-  app.register(ApolloClientToken, ApolloUniversalClient);
-  app.register(GraphQLEndpointToken, '...');
+  app.enhance(RenderToken, ApolloRenderEnhancer);
+  app.register(ApolloClientToken, ApolloClientPlugin);
+  app.register(GraphQLEndpointToken, 'http://website.com/graphql');
   return app;
 }
 ```
@@ -152,13 +151,54 @@ Optional - the endpoint for serving the graphql API. Defaults to `'/graphql'`. T
 type GraphQLEndpoint = string;
 ```
 
-#### Plugin
+##### `GetApolloClientCacheToken`
 
 ```js
-import ApolloPlugin from 'fusion-plugin-apollo';
+import {GetApolloClientCacheToken} from 'fusion-apollo-universal-client';
 ```
 
-A plugin which is responsible for rendering (both virtual DOM and server-side rendering).
+Optional - A function that returns an Apollo [cache implementation](https://www.apollographql.com/docs/react/advanced/caching.html).
+
+```js
+type GetApolloClientCache = (ctx: Context) => ApolloCache
+```
+
+###### Default value
+
+The default cache implementation uses [InMemoryCache](https://github.com/apollographql/apollo-client/tree/master/packages/apollo-cache-inmemory).
+
+##### `ApolloClientCredentialsToken`
+
+```js
+import {ApolloClientCredentialsToken} from 'fusion-apollo-universal-client';
+```
+
+Optional - A configuration value that provides the value of credentials value passed directly into the [fetch implementation](https://github.com/github/fetch). 
+The default value is `same-origin`.
+
+```js
+type ApolloClientCredentials = 'omit' | 'include' | 'same-origin'
+```
+
+##### `GetApolloClientLinksToken`
+
+```js
+import {GetApolloClientLinksToken} from 'fusion-apollo-universal-client';
+```
+
+Optional - A configuration value that provides a array of [ApolloLinks](https://www.apollographql.com/docs/link/composition.html). The default links are provided as an argument to the provided function.
+
+```js
+type GetApolloClientLinks = (Array<ApolloLinkType>) => Array<ApolloLinkType>
+```
+
+##### `ApolloClientResolversToken`
+
+```js
+import { ApolloClientResolversToken } from "fusion-apollo-universal-client";
+```
+
+Optional - Provides the resolvers for [local state management](https://www.apollographql.com/docs/react/essentials/local-state.html).
 
 #### gql
 

--- a/docs/migrations/00159.md
+++ b/docs/migrations/00159.md
@@ -1,18 +1,23 @@
 ## v2.0.0
 
-The 2.0.0 release also marks a refactor from `fusion-apollo` as an app wrapper into `fusion-plugin-apollo` which is implemented as a plugin to be
-registered on the `RenderToken`. We also consolidated the code from `fusion-apollo-universal-server` into this module. The migration looks like this:
+The 2.0.0 release also marks a refactor from `fusion-apollo` as an app wrapper into `fusion-plugin-apollo` which is implemented as an enhancer to be
+registered on the `RenderToken`. We also consolidated the code from `fusion-apollo-universal-server` and `fusion-apollo-universal-client` into this module. 
+The migration looks like this:
 
 ```diff
 +import {RenderToken} from 'fusion-core';
 +import App from 'fusion-react';
 -import App from 'fusion-apollo';
-+import ApolloPlugin from 'fusion-plugin-apollo';
 -import ApolloServer from 'fusion-plugin-apollo-server';
+-import ApolloClient from 'fusion-apollo-universal-client';
++import {
++  ApolloRenderEnhancer,
++  ApolloClientPlugin,
++}from 'fusion-plugin-apollo';
 
 export default async function main() {
   const app = new App();
-+ app.register(RenderToken, ApolloPlugin);
++ app.enhance(RenderToken, ApolloRenderEnhancer);
 - app.register(ApolloServer); // apollo-server 2.0 now integrated by default
 - app.middleware(require('koa-bodyparser')()); // Body parsing for /graphql route is included by default now with apollo-server 2
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "apollo-link-http": "^1.5.12",
     "apollo-link-schema": "^1.1.4",
     "apollo-server-koa": "^2.4.8",
-    "koa-compose": "^4.1.0",
-    "nyc": "^13.3.0"
+    "koa-compose": "^4.1.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
@@ -60,7 +59,8 @@
     "redux": "^4.0.1",
     "tape-cup": "^4.7.1",
     "unfetch": "^4.1.0",
-    "unitest": "^2.1.1"
+    "unitest": "^2.1.1",
+    "nyc": "^13.3.0"
   },
   "peerDependencies": {
     "fusion-core": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "apollo-link-http": "^1.5.12",
     "apollo-link-schema": "^1.1.4",
     "apollo-server-koa": "^2.4.8",
-    "koa-compose": "^4.1.0"
+    "koa-compose": "^4.1.0",
+    "nyc": "^13.3.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
@@ -58,6 +59,7 @@
     "react-dom": "^16.6.3",
     "redux": "^4.0.1",
     "tape-cup": "^4.7.1",
+    "unfetch": "^4.1.0",
     "unitest": "^2.1.1"
   },
   "peerDependencies": {
@@ -74,6 +76,8 @@
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",
     "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
+    "cover": "npm run build-test && npm run just-cover",
+    "just-cover": "nyc --reporter=cobertura --reporter=text npm run just-test",
     "test": "npm run build-test && npm run just-test",
     "prepublish": "npm run transpile"
   },

--- a/src/__tests__/exports.js
+++ b/src/__tests__/exports.js
@@ -6,7 +6,8 @@
  * @flow
  */
 import test from 'tape-cup';
-import plugin, {
+import {
+  ApolloRenderEnhancer,
   ApolloContextToken,
   GraphQLSchemaToken,
   gql,
@@ -17,7 +18,7 @@ test('fusion-tokens exports', t => {
   t.ok(ApolloContextToken, 'exports ApolloContextToken');
   t.ok(GraphQLSchemaToken, 'exports GraphQLSchemaToken');
   t.ok(GraphQLEndpointToken, 'exports GraphQLSchemaToken');
-  t.ok(plugin, 'exports plugin');
+  t.ok(ApolloRenderEnhancer, 'exports plugin');
   t.equal(typeof gql, 'function', 'exports a gql function');
   t.throws(gql, 'gql function throws an error if executed directly');
   t.end();

--- a/src/__tests__/integration.node.js
+++ b/src/__tests__/integration.node.js
@@ -7,7 +7,11 @@
  */
 import test from 'tape-cup';
 import React from 'react';
-import plugin, {GraphQLSchemaToken, ApolloClientToken} from '../index';
+import {
+  ApolloRenderEnhancer,
+  GraphQLSchemaToken,
+  ApolloClientToken,
+} from '../index';
 import gql from 'graphql-tag';
 import App from 'fusion-react/dist';
 import {RenderToken} from 'fusion-core';
@@ -36,7 +40,7 @@ async function testApp(el, {typeDefs, resolvers}) {
       },
     }),
   });
-  app.register(RenderToken, plugin);
+  app.enhance(RenderToken, ApolloRenderEnhancer);
   app.register(GraphQLSchemaToken, schema);
   app.register(ApolloClientToken, ctx => {
     // $FlowFixMe

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -11,12 +11,15 @@
 import test from 'tape-cup';
 import {getSimulator} from 'fusion-test-utils';
 import React from 'react';
-import render from '../server';
-import plugin, {GraphQLSchemaToken, ApolloClientToken} from '../index';
+import {
+  ApolloRenderEnhancer,
+  GraphQLSchemaToken,
+  ApolloClientToken,
+} from '../index';
 import gql from 'graphql-tag';
 import {makeExecutableSchema} from 'graphql-tools';
 import {Query} from 'react-apollo';
-import App from 'fusion-react/dist';
+import App from 'fusion-react';
 import {RenderToken} from 'fusion-core';
 import {ApolloClient} from 'apollo-client';
 import {InMemoryCache} from 'apollo-cache-inmemory';
@@ -27,7 +30,7 @@ import fetch from 'node-fetch';
 function testApp(el, {typeDefs, resolvers}) {
   const app = new App(el);
   const schema = makeExecutableSchema({typeDefs, resolvers});
-  app.register(RenderToken, plugin);
+  app.enhance(RenderToken, ApolloRenderEnhancer);
   app.register(GraphQLSchemaToken, schema);
   app.register(ApolloClientToken, ctx => {
     return new ApolloClient({
@@ -42,21 +45,10 @@ function testApp(el, {typeDefs, resolvers}) {
   return app;
 }
 
-test('renders', async t => {
-  const rendered = await render(
-    React.createElement('span', null, 'hello'),
-    // $FlowFixMe
-    console
-  );
-  t.ok(/<span/.test(rendered), 'has right tag');
-  t.ok(/hello/.test(rendered), 'has right text');
-  t.end();
-});
-
 test('Server renders without schema', async t => {
   const el = <div>Hello World</div>;
   const app = new App(el);
-  app.register(RenderToken, plugin);
+  app.enhance(RenderToken, ApolloRenderEnhancer);
   app.register(ApolloClientToken, ctx => {
     return new ApolloClient({
       ssrMode: true,

--- a/src/apollo-client/__tests__/exports.js
+++ b/src/apollo-client/__tests__/exports.js
@@ -1,0 +1,27 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import test from 'tape-cup';
+import {
+  ApolloClientPlugin,
+  GetApolloClientCacheToken,
+  ApolloClientCredentialsToken,
+  GetApolloClientLinksToken,
+  ApolloClientDefaultOptionsToken,
+  ApolloClientResolversToken,
+} from '../index.js';
+
+test('exports', t => {
+  t.ok(ApolloClientPlugin, 'exports ApolloClientPlugin');
+  t.ok(GetApolloClientCacheToken, 'exports GetApolloClientCacheToken');
+  t.ok(ApolloClientCredentialsToken, 'exports ApolloClientCredentialsToken');
+  t.ok(GetApolloClientLinksToken, 'exports ApolloClientAuthKeyToken');
+  t.ok(ApolloClientDefaultOptionsToken, 'exports ApolloClientAuthKeyToken');
+  t.ok(ApolloClientResolversToken, 'exports ApolloClientResolversToken');
+  t.end();
+});

--- a/src/apollo-client/__tests__/index.js
+++ b/src/apollo-client/__tests__/index.js
@@ -1,0 +1,55 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {InMemoryCache} from 'apollo-cache-inmemory';
+import App, {createPlugin} from 'fusion-core';
+import {getSimulator} from 'fusion-test-utils';
+import {ApolloClientToken} from '../../tokens';
+import {ApolloLink} from 'apollo-link';
+import {FetchToken} from 'fusion-tokens';
+import unfetch from 'unfetch';
+import test from 'tape-cup';
+
+import {ApolloClientPlugin, GetApolloClientLinksToken} from '../index.js';
+
+test('ApolloUniveralClient', async t => {
+  const app = new App('el', el => el);
+  app.register(GetApolloClientLinksToken, links => [
+    new ApolloLink(),
+    ...links,
+  ]);
+  app.register(ApolloClientToken, ApolloClientPlugin);
+  app.register(FetchToken, unfetch);
+
+  const clients = [];
+  const testPlugin = createPlugin({
+    deps: {
+      universalClient: ApolloClientToken,
+    },
+    middleware({universalClient}) {
+      return async (ctx, next) => {
+        const client = universalClient(ctx, {});
+        clients.push(client);
+        t.ok(client.link);
+        t.ok(client.cache instanceof InMemoryCache);
+        // memoizes the client on ctx correctly
+        t.equal(client, universalClient(ctx, {}));
+        return next();
+      };
+    },
+  });
+  app.register(testPlugin);
+
+  const simulator = getSimulator(app);
+  await simulator.render('/');
+  await simulator.render('/');
+  t.equal(clients.length, 2);
+  t.notEqual(clients[0], clients[1]);
+  t.notEqual(clients[0].cache, clients[1].cache);
+  t.end();
+});

--- a/src/apollo-client/__tests__/local-state.js
+++ b/src/apollo-client/__tests__/local-state.js
@@ -1,0 +1,85 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {ApolloClientToken, GraphQLSchemaToken} from '../../tokens';
+import App, {createPlugin} from 'fusion-core';
+import {getSimulator} from 'fusion-test-utils';
+import {FetchToken} from 'fusion-tokens';
+import {buildSchema} from 'graphql';
+import gql from 'graphql-tag';
+import unfetch from 'unfetch';
+import test from 'tape-cup';
+
+import {ApolloClientResolversToken, ApolloClientPlugin} from '../index.js';
+
+test('local state management', async t => {
+  const app = new App('el', el => el);
+  app.register(ApolloClientToken, ApolloClientPlugin);
+  app.register(
+    GraphQLSchemaToken,
+    (buildSchema(`
+      type Query {
+        query: String!
+      }
+
+      type Mutation {
+        mutate: String # returns nothing
+      }
+    `): any)
+  );
+  app.register(FetchToken, unfetch);
+
+  let mutationCalled = false;
+  app.register(ApolloClientResolversToken, {
+    Query: {
+      query: () => 'foo',
+    },
+    Mutation: {
+      mutate: async () => {
+        mutationCalled = true;
+      },
+    },
+  });
+
+  const testPlugin = createPlugin({
+    deps: {
+      universalClient: ApolloClientToken,
+    },
+    middleware({universalClient}) {
+      return async (ctx, next) => {
+        const client = universalClient(ctx, {});
+
+        const {data} = await client.query({
+          query: gql`
+            query {
+              query @client
+            }
+          `,
+        });
+        t.equal(data.query, 'foo');
+
+        t.equal(mutationCalled, false);
+        await client.mutate({
+          mutation: gql`
+            mutation {
+              mutate @client
+            }
+          `,
+        });
+        t.equal(mutationCalled, true);
+
+        return next();
+      };
+    },
+  });
+  app.register(testPlugin);
+
+  const simulator = getSimulator(app);
+  await simulator.render('/');
+  t.end();
+});

--- a/src/apollo-client/index.js
+++ b/src/apollo-client/index.js
@@ -1,0 +1,144 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {createPlugin, createToken} from 'fusion-core';
+import {FetchToken} from 'fusion-tokens';
+import {
+  GraphQLSchemaToken,
+  ApolloContextToken,
+  GraphQLEndpointToken,
+} from '../tokens';
+import {ApolloClient} from 'apollo-client';
+import {HttpLink} from 'apollo-link-http';
+import {from as apolloLinkFrom} from 'apollo-link';
+import {SchemaLink} from 'apollo-link-schema';
+import type {ApolloCache, ApolloClientOptions} from 'apollo-client';
+
+import type {Context, FusionPlugin, Token} from 'fusion-core';
+import {InMemoryCache} from 'apollo-cache-inmemory';
+
+export const GetApolloClientCacheToken: Token<
+  (ctx: Context) => ApolloCache<mixed>
+> = createToken('GetApolloClientCacheToken');
+
+export const ApolloClientCredentialsToken: Token<string> = createToken(
+  'ApolloClientCredentialsToken'
+);
+
+export const ApolloClientDefaultOptionsToken: Token<
+  $PropertyType<ApolloClientOptions<any>, 'defaultOptions'>
+> = createToken('ApolloClientDefaultOptionsToken');
+
+type ApolloLinkType = {request: (operation: any, forward: any) => any};
+
+export const GetApolloClientLinksToken: Token<
+  (Array<ApolloLinkType>, ctx: Context) => Array<ApolloLinkType>
+> = createToken('GetApolloClientLinksToken');
+
+export const ApolloClientResolversToken: Token<
+  ResolverMapType | $ReadOnlyArray<ResolverMapType>
+> = createToken('ApolloClientResolversToken');
+
+type ResolverMapType = {
+  +[key: string]: {
+    +[field: string]: (
+      rootValue?: any,
+      args?: any,
+      context?: any,
+      info?: any
+    ) => any,
+  },
+};
+
+type ApolloClientDepsType = {
+  getCache: typeof GetApolloClientCacheToken.optional,
+  endpoint: typeof GraphQLEndpointToken.optional,
+  fetch: typeof FetchToken,
+  includeCredentials: typeof ApolloClientCredentialsToken.optional,
+  apolloContext: typeof ApolloContextToken.optional,
+  getApolloLinks: typeof GetApolloClientLinksToken.optional,
+  schema: typeof GraphQLSchemaToken.optional,
+  resolvers: typeof ApolloClientResolversToken.optional,
+  defaultOptions: typeof ApolloClientDefaultOptionsToken.optional,
+};
+
+type InitApolloClientType = (
+  ctx: Context,
+  initialState: mixed
+) => ApolloClient<mixed>;
+
+function Container() {}
+
+const ApolloClientPlugin: FusionPlugin<
+  ApolloClientDepsType,
+  InitApolloClientType
+> = createPlugin({
+  deps: {
+    getCache: GetApolloClientCacheToken.optional,
+    endpoint: GraphQLEndpointToken.optional,
+    fetch: FetchToken,
+    includeCredentials: ApolloClientCredentialsToken.optional,
+    apolloContext: ApolloContextToken.optional,
+    getApolloLinks: GetApolloClientLinksToken.optional,
+    schema: GraphQLSchemaToken.optional,
+    resolvers: ApolloClientResolversToken.optional,
+    defaultOptions: ApolloClientDefaultOptionsToken.optional,
+  },
+  provides({
+    getCache = ctx => new InMemoryCache(),
+    endpoint = '/graphql',
+    fetch,
+    includeCredentials = 'same-origin',
+    apolloContext = ctx => ctx,
+    getApolloLinks,
+    schema,
+    resolvers,
+    defaultOptions,
+  }) {
+    function getClient(ctx, initialState) {
+      const cache = getCache(ctx);
+      const connectionLink =
+        schema && __NODE__
+          ? new SchemaLink({
+              schema,
+              context:
+                typeof apolloContext === 'function'
+                  ? apolloContext(ctx)
+                  : apolloContext,
+            })
+          : new HttpLink({
+              uri: endpoint,
+              credentials: includeCredentials,
+              fetch,
+            });
+
+      const links: Array<ApolloLinkType> = getApolloLinks
+        ? getApolloLinks([connectionLink], ctx)
+        : [connectionLink];
+
+      const client = new ApolloClient({
+        ssrMode: __NODE__,
+        connectToDevTools: __BROWSER__ && __DEV__,
+        link: apolloLinkFrom(links),
+        cache: cache.restore(initialState),
+        resolvers,
+        defaultOptions,
+      });
+      return client;
+    }
+    return (ctx: Context, initialState: mixed) => {
+      if (ctx.memoized.has(Container)) {
+        return ctx.memoized.get(Container);
+      }
+      const client = getClient(ctx, initialState);
+      ctx.memoized.set(Container, client);
+      return client;
+    };
+  },
+});
+export {ApolloClientPlugin};

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,12 @@
  * @flow
  */
 import type {DocumentNode} from 'graphql';
-import Plugin from './plugin';
+import ApolloRenderEnhancer from './plugin';
 
 export * from './tokens.js';
-export default Plugin;
+export * from './apollo-client/index.js';
+
+export {ApolloRenderEnhancer};
 
 export function gql(path: string): DocumentNode {
   throw new Error('fusion-plugin-apollo/gql should be replaced at build time');

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,11 +13,9 @@ import {createPlugin, html} from 'fusion-core';
 
 import {ApolloProvider} from 'react-apollo';
 
-import type {Context} from 'fusion-core';
-import {prepare} from 'fusion-react';
+import type {Context, Render} from 'fusion-core';
 
 import serverRender from './server';
-import clientRender from './client';
 import {LoggerToken} from 'fusion-tokens';
 import {ApolloServer} from 'apollo-server-koa';
 import compose from 'koa-compose';
@@ -55,82 +53,86 @@ function getDeps(): DepsType {
   };
 }
 
-export default createPlugin<DepsType, ProvidesType>({
-  deps: getDeps(),
-  provides(deps) {
-    return async (el, ctx) => {
-      return prepare(el).then(() => {
-        return __NODE__ ? serverRender(el, deps.logger) : clientRender(el);
-      });
-    };
-  },
-  middleware({
-    schema,
-    endpoint = '/graphql',
-    getApolloClient,
-    apolloContext = ctx => {
-      return ctx;
-    },
-  }) {
-    const renderMiddleware = (ctx, next) => {
-      if (!ctx.element) {
-        return next();
-      }
-      let initialState = null;
+export default (renderFn: Render) =>
+  createPlugin<DepsType, ProvidesType>({
+    deps: getDeps(),
+    provides(deps) {
       if (__BROWSER__) {
-        // Deserialize initial state for the browser
-        const apolloState = document.getElementById('__APOLLO_STATE__');
-        if (apolloState) {
-          initialState = JSON.parse(unescape(apolloState.textContent));
+        return renderFn;
+      }
+      return (el, ctx) => {
+        return serverRender(el, deps.logger).then(() => {
+          return renderFn(el, ctx);
+        });
+      };
+    },
+    middleware({
+      schema,
+      endpoint = '/graphql',
+      getApolloClient,
+      apolloContext = ctx => {
+        return ctx;
+      },
+    }) {
+      const renderMiddleware = (ctx, next) => {
+        if (!ctx.element) {
+          return next();
         }
-      }
-      // Create the client and apollo provider
-      const client = getApolloClient(ctx, initialState);
-      ctx.element = (
-        <ApolloCacheContext.Provider value={client.cache}>
-          <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
-        </ApolloCacheContext.Provider>
-      );
-
-      if (__NODE__) {
-        // Serialize state into html on server side render
-        const initialState = client.cache && client.cache.extract();
-        const serialized = JSON.stringify(initialState);
-        const script = html`
-          <script type="application/json" id="__APOLLO_STATE__">
-            ${serialized}
-          </script>
-        `;
-        ctx.template.body.push(script);
-      }
-
-      return next();
-    };
-    if (__NODE__ && schema) {
-      const server = new ApolloServer({
-        schema,
-        // investigate other options
-        context: ({ctx}) => {
-          if (typeof apolloContext === 'function') {
-            return apolloContext(ctx);
+        let initialState = null;
+        if (__BROWSER__) {
+          // Deserialize initial state for the browser
+          const apolloState = document.getElementById('__APOLLO_STATE__');
+          if (apolloState) {
+            initialState = JSON.parse(unescape(apolloState.textContent));
           }
-          return apolloContext;
-        },
-      });
-      let serverMiddleware = [];
-      server.applyMiddleware({
-        // switch to server.getMiddleware once https://github.com/apollographql/apollo-server/pull/2435 lands
-        app: {
-          use: m => {
-            serverMiddleware.push(m);
+        }
+        // Create the client and apollo provider
+        const client = getApolloClient(ctx, initialState);
+        ctx.element = (
+          <ApolloCacheContext.Provider value={client.cache}>
+            <ApolloProvider client={client}>{ctx.element}</ApolloProvider>
+          </ApolloCacheContext.Provider>
+        );
+
+        if (__NODE__) {
+          // Serialize state into html on server side render
+          const initialState = client.cache && client.cache.extract();
+          const serialized = JSON.stringify(initialState);
+          const script = html`
+            <script type="application/json" id="__APOLLO_STATE__">
+              ${serialized}
+            </script>
+          `;
+          ctx.template.body.push(script);
+        }
+
+        return next();
+      };
+      if (__NODE__ && schema) {
+        const server = new ApolloServer({
+          schema,
+          // investigate other options
+          context: ({ctx}) => {
+            if (typeof apolloContext === 'function') {
+              return apolloContext(ctx);
+            }
+            return apolloContext;
           },
-        },
-        // investigate other options
-        path: endpoint,
-      });
-      return compose([...serverMiddleware, renderMiddleware]);
-    } else {
-      return renderMiddleware;
-    }
-  },
-});
+        });
+        let serverMiddleware = [];
+        server.applyMiddleware({
+          // switch to server.getMiddleware once https://github.com/apollographql/apollo-server/pull/2435 lands
+          app: {
+            use: m => {
+              serverMiddleware.push(m);
+            },
+          },
+          // investigate other options
+          path: endpoint,
+        });
+        return compose([...serverMiddleware, renderMiddleware]);
+      } else {
+        return renderMiddleware;
+      }
+    },
+  });

--- a/src/server.js
+++ b/src/server.js
@@ -7,8 +7,7 @@
  */
 
 /* eslint-env node */
-import {renderToStringWithData} from 'react-apollo';
-import {renderToString} from 'react-dom/server';
+import {getDataFromTree} from 'react-apollo';
 import type {Logger} from 'fusion-tokens';
 
 import type {Element} from 'react';
@@ -19,12 +18,7 @@ import type {Element} from 'react';
 // This allows us to still render with data in the happy case, and defer to client side rendering if any queries fail. This also acts as a form
 // of retrying from the browser.
 export default (root: Element<*>, logger?: Logger) => {
-  return renderToStringWithData(root)
-    .catch(e => {
-      logger && logger.error('SSR Failed with Error', e);
-      return renderToString(root);
-    })
-    .then(content => {
-      return `<div id='root'>${content}</div>`;
-    });
+  return getDataFromTree(root).catch(e => {
+    logger && logger.error('SSR Failed with Error', e);
+  });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,10 +1408,22 @@ apollo-utilities@1.2.1, apollo-utilities@^1.0.1, apollo-utilities@^1.2.1:
     ts-invariant "^0.2.1"
     tslib "^1.9.3"
 
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
+  dependencies:
+    default-require-extensions "^2.0.0"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -1764,6 +1776,16 @@ cache-content-type@^1.0.0:
     mime-types "^2.1.18"
     ylru "^1.2.0"
 
+caching-transform@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-3.0.2.tgz#601d46b91eca87687a281e71cef99791b0efca70"
+  integrity sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==
+  dependencies:
+    hasha "^3.0.0"
+    make-dir "^2.0.0"
+    package-hash "^3.0.0"
+    write-file-atomic "^2.4.2"
+
 callsites@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
@@ -1783,6 +1805,11 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30000792:
   version "1.0.30000955"
@@ -1914,6 +1941,15 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 co-body@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/co-body/-/co-body-4.2.0.tgz#74df20fa73262125dc45482af04e342ea8db3515"
@@ -1959,6 +1995,16 @@ commander@2.11.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
   integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
 
+commander@~2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -2003,7 +2049,7 @@ content-type@^1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -2093,6 +2139,14 @@ create-universal-package@^3.4.6:
     rollup-pluginutils "^2.0.1"
     webpack "^3.10.0"
 
+cross-spawn@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2102,7 +2156,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.5:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -2156,7 +2210,7 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -2170,7 +2224,7 @@ debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2194,6 +2248,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
+  dependencies:
+    strip-bom "^3.0.0"
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -2343,6 +2404,13 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
 enhanced-resolve@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
@@ -2401,6 +2469,11 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
     next-tick "^1.0.0"
+
+es6-error@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
@@ -2734,6 +2807,19 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -2851,6 +2937,15 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -2895,6 +2990,14 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+foreground-child@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
+  integrity sha1-T9ca0t/elnibmApcCilZN8svXOk=
+  dependencies:
+    cross-spawn "^4"
+    signal-exit "^3.0.0"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3020,6 +3123,13 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -3093,7 +3203,7 @@ globals@^11.1.0, globals@^11.5.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -3151,6 +3261,17 @@ graphql@^14.1.1:
   integrity sha512-dlFHRtxsL4sBy1C1e3v64IUd5ndZhAOHZ/z3Dr4Nm6+cvr9elrnz4BhMF9h9mRBBnhUCGLc4GH4xvPbKG6sUeA==
   dependencies:
     iterall "^1.2.2"
+
+handlebars@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
+  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-flag@^2.0.0:
   version "2.0.0"
@@ -3239,6 +3360,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hasha@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
+  integrity sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
+  dependencies:
+    is-stream "^1.0.1"
 
 highland@^2.5.1:
   version "2.13.3"
@@ -3420,6 +3548,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -3584,7 +3717,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -3658,7 +3791,14 @@ istanbul-lib-coverage@^2.0.3:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#0b891e5ad42312c2b9488554f603795f9a2211ba"
   integrity sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==
 
-istanbul-lib-instrument@^3.0.0:
+istanbul-lib-hook@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz#e0e581e461c611be5d0e5ef31c5f0109759916fb"
+  integrity sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==
+  dependencies:
+    append-transform "^1.0.0"
+
+istanbul-lib-instrument@^3.0.0, istanbul-lib-instrument@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz#a2b5484a7d445f1f311e93190813fa56dfb62971"
   integrity sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==
@@ -3670,6 +3810,33 @@ istanbul-lib-instrument@^3.0.0:
     "@babel/types" "^7.0.0"
     istanbul-lib-coverage "^2.0.3"
     semver "^5.5.0"
+
+istanbul-lib-report@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz#bfd324ee0c04f59119cb4f07dab157d09f24d7e4"
+  integrity sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==
+  dependencies:
+    istanbul-lib-coverage "^2.0.3"
+    make-dir "^1.3.0"
+    supports-color "^6.0.0"
+
+istanbul-lib-source-maps@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz#f1e817229a9146e8424a28e5d69ba220fda34156"
+  integrity sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^2.0.3"
+    make-dir "^1.3.0"
+    rimraf "^2.6.2"
+    source-map "^0.6.1"
+
+istanbul-reports@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.1.1.tgz#72ef16b4ecb9a4a7bd0e2001e00f95d1eec8afa9"
+  integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
+  dependencies:
+    handlebars "^4.1.0"
 
 iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
   version "1.2.2"
@@ -3879,6 +4046,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
+
 leven@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -3950,6 +4124,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -3996,6 +4175,28 @@ lru-cache@^5.0.0:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+make-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
+
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -4062,6 +4263,15 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -4074,6 +4284,13 @@ merge-descriptors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -4141,6 +4358,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -4167,6 +4389,11 @@ minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
@@ -4276,7 +4503,7 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
-neo-async@^2.5.0:
+neo-async@^2.5.0, neo-async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
@@ -4447,6 +4674,36 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
+nyc@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-13.3.0.tgz#da4dbe91a9c8b9ead3f4f3344c76f353e3c78c75"
+  integrity sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^3.0.1"
+    convert-source-map "^1.6.0"
+    find-cache-dir "^2.0.0"
+    find-up "^3.0.0"
+    foreground-child "^1.5.6"
+    glob "^7.1.3"
+    istanbul-lib-coverage "^2.0.3"
+    istanbul-lib-hook "^2.0.3"
+    istanbul-lib-instrument "^3.1.0"
+    istanbul-lib-report "^2.0.4"
+    istanbul-lib-source-maps "^3.0.2"
+    istanbul-reports "^2.1.1"
+    make-dir "^1.3.0"
+    merge-source-map "^1.1.0"
+    resolve-from "^4.0.0"
+    rimraf "^2.6.3"
+    signal-exit "^3.0.2"
+    spawn-wrap "^1.4.2"
+    test-exclude "^5.1.0"
+    uuid "^3.3.2"
+    yargs "^12.0.5"
+    yargs-parser "^11.1.1"
+
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -4515,7 +4772,7 @@ on-finished@^2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4540,6 +4797,14 @@ optimism@^0.6.9:
   integrity sha512-xoQm2lvXbCA9Kd7SCx6y713Y7sZ6fUc5R6VYpoL5M6svKJbTuvtNopexK8sO8K4s0EOUYHuPN2+yAEsNyRggkQ==
   dependencies:
     immutable-tuple "^0.4.9"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -4572,6 +4837,15 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -4585,10 +4859,20 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -4627,6 +4911,16 @@ p-try@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.1.0.tgz#c1a0f1030e97de018bb2c718929d2af59463e505"
   integrity sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==
+
+package-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-3.0.0.tgz#50183f2d36c9e3e528ea0a8605dff57ce976f88e"
+  integrity sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==
+  dependencies:
+    graceful-fs "^4.1.15"
+    hasha "^3.0.0"
+    lodash.flattendeep "^4.4.0"
+    release-zalgo "^1.0.0"
 
 pako@~1.0.5:
   version "1.0.10"
@@ -4759,12 +5053,24 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -4857,6 +5163,14 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -5085,6 +5399,13 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+  dependencies:
+    es6-error "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -5175,7 +5496,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.6.3, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2.6.3, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -5259,7 +5580,7 @@ scheduler@^0.13.6:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
@@ -5396,10 +5717,22 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, sour
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@~0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
+  integrity sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==
+  dependencies:
+    foreground-child "^1.5.6"
+    mkdirp "^0.5.0"
+    os-homedir "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -5492,7 +5825,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -5593,6 +5926,13 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@^1.0.2, symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -5674,7 +6014,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-test-exclude@^5.0.0:
+test-exclude@^5.0.0, test-exclude@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.1.0.tgz#6ba6b25179d2d38724824661323b73e03c0c1de1"
   integrity sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==
@@ -5817,6 +6157,14 @@ uglify-js@^2.8.29:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
+uglify-js@^3.1.4:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.3.tgz#d490bb5347f23025f0c1bc0dee901d98e4d6b063"
+  integrity sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==
+  dependencies:
+    commander "~2.19.0"
+    source-map "~0.6.1"
+
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
@@ -5835,6 +6183,11 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
+unfetch@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -6036,7 +6389,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.12, which@^1.2.14, which@^1.2.9:
+which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -6060,6 +6413,11 @@ wordwrap@0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
   integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
+
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
@@ -6077,6 +6435,15 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
 
 write@1.0.3:
   version "1.0.3"
@@ -6118,6 +6485,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -6128,12 +6500,38 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^12.0.5:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
This updates the API to include the logic from `fusion-apollo-universal-client` and to use a render enhancer pattern.