### PR TITLE
Update flow to 0.96 and fix flow error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-jest": "^22.1.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.94.0",
+    "flow-bin": "^0.96.0",
     "fusion-core": "^1.10.4",
     "fusion-react": "^2.0.0",
     "fusion-test-utils": "^1.3.0",
@@ -52,6 +52,7 @@
     "graphql-tag": "^2.10.0",
     "graphql-tools": "^4.0.3",
     "node-fetch": "^2.3.0",
+    "nyc": "^13.3.0",
     "prettier": "^1.15.2",
     "react": "^16.6.3",
     "react-apollo": "^2.3.2",
@@ -59,8 +60,7 @@
     "redux": "^4.0.1",
     "tape-cup": "^4.7.1",
     "unfetch": "^4.1.0",
-    "unitest": "^2.1.1",
-    "nyc": "^13.3.0"
+    "unitest": "^2.1.1"
   },
   "peerDependencies": {
     "fusion-core": "^1.10.4",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -100,7 +100,7 @@ export default (renderFn: Render) =>
           const serialized = JSON.stringify(initialState);
           const script = html`
             <script type="application/json" id="__APOLLO_STATE__">
-              ${serialized}
+              ${String(serialized)}
             </script>
           `;
           ctx.template.body.push(script);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,10 +2974,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@^0.94.0:
-  version "0.94.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
-  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
+flow-bin@^0.96.0:
+  version "0.96.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.96.0.tgz#3b0379d97304dc1879ae6db627cd2d6819998661"
+  integrity sha512-OSxERs0EdhVxEVCst/HmlT/RcnXsQQIRqcfK9J9wC8/93JQj+xQz4RtlsmYe1PSRYaozuDLyPS5pIA81Zwzaww==
 
 for-each@~0.3.3:
   version "0.3.3"


### PR DESCRIPTION
The upgrade resulted in an error like: 

![image](https://user-images.githubusercontent.com/122602/55841966-5b2a7d80-5ae6-11e9-8316-3cb214c7f704.png)

Casting to a string seems to fix it.

Fixes #163