### PR TITLE
Move cache extraction into after await next

### DIFF
--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -125,6 +125,7 @@ test('SSR with <Query>', async t => {
   const ctx = await simulator.render('/');
   t.equal(ctx.rendered.includes('test'), true, 'renders correctly');
   t.equal(ctx.rendered.includes('Loading'), false, 'does not render loading');
+  t.ok(ctx.body.includes('ROOT_QUERY'), 'includes serialized data');
   t.end();
 });
 

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -125,6 +125,7 @@ test('SSR with <Query>', async t => {
   const ctx = await simulator.render('/');
   t.equal(ctx.rendered.includes('test'), true, 'renders correctly');
   t.equal(ctx.rendered.includes('Loading'), false, 'does not render loading');
+  // $FlowFixMe
   t.ok(ctx.body.includes('ROOT_QUERY'), 'includes serialized data');
   t.end();
 });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,7 +74,7 @@ export default (renderFn: Render) =>
         return ctx;
       },
     }) {
-      const renderMiddleware = (ctx, next) => {
+      const renderMiddleware = async (ctx, next) => {
         if (!ctx.element) {
           return next();
         }
@@ -94,6 +94,8 @@ export default (renderFn: Render) =>
           </ApolloCacheContext.Provider>
         );
 
+        await next();
+
         if (__NODE__) {
           // Serialize state into html on server side render
           const initialState = client.cache && client.cache.extract();
@@ -105,8 +107,6 @@ export default (renderFn: Render) =>
           `;
           ctx.template.body.push(script);
         }
-
-        return next();
       };
       if (__NODE__ && schema) {
         const server = new ApolloServer({


### PR DESCRIPTION
This fixes a bug where the extracted cache was an
empty object.