### PR TITLE
Use unescape exported from fusion-core

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,7 +9,7 @@
 /* eslint-env browser */
 import React from 'react';
 
-import {createPlugin, html} from 'fusion-core';
+import {createPlugin, html, unescape} from 'fusion-core';
 
 import {ApolloProvider} from 'react-apollo';
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -100,11 +100,8 @@ export default (renderFn: Render) =>
           // Serialize state into html on server side render
           const initialState = client.cache && client.cache.extract();
           const serialized = JSON.stringify(initialState);
-          const script = html`
-            <script type="application/json" id="__APOLLO_STATE__">
-              ${String(serialized)}
-            </script>
-          `;
+          // eslint-disable-next-line prettier/prettier
+          const script = html`<script type="application/json" id="__APOLLO_STATE__">${String(serialized)}</script>`;
           ctx.template.body.push(script);
         }
       };


### PR DESCRIPTION
At some point we lost the unescape import. This didn't fail lint or flow
since unescape is a valid browser global.